### PR TITLE
feat: add in-memory cache for transformed code

### DIFF
--- a/tests/example/apps/nextjs/build-and-bench.mjs
+++ b/tests/example/apps/nextjs/build-and-bench.mjs
@@ -1,0 +1,30 @@
+import { execSync } from 'child_process';
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import prettyMs from 'pretty-ms';
+import { fileURLToPath } from 'url';
+
+const CWD = join(fileURLToPath(import.meta.url), '..');
+
+async function buildAndBench() {
+  // ignore error
+  await fs.rm('.next', { recursive: true, force: true }).catch(() => {});
+
+  execSync(`pnpm run build`, {
+    cwd: CWD,
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      TRACE_TARGET: 'jaeger',
+    },
+  });
+  const traceString = await fs.readFile(join(CWD, '.next', 'trace'), 'utf8');
+  const traces = traceString
+    .split('\n')
+    .filter((line) => line)
+    .map((line) => JSON.parse(line));
+  const { duration } = traces.pop().find(({ name }) => name === 'next-build');
+  console.info('next build duration: ', prettyMs(duration / 1000));
+}
+
+buildAndBench();

--- a/tests/example/apps/nextjs/next.config.js
+++ b/tests/example/apps/nextjs/next.config.js
@@ -4,7 +4,7 @@ const withLinaria = require('../../../../');
 const config = {
   experimental: {
     appDir: true,
-    transpilePackages: ['ui-kit'],
   },
+  transpilePackages: ['ui-kit'],
 };
 module.exports = withLinaria(config);

--- a/tests/example/packages/ui-kit/generateBigFile.js
+++ b/tests/example/packages/ui-kit/generateBigFile.js
@@ -1,0 +1,23 @@
+const fs = require('fs');
+const path = require('path');
+
+const createBigFile = (size) => {
+  const file = fs.createWriteStream(
+    path.join(__dirname, 'linariaComponents.tsx'),
+  );
+  file.write(`import { styled } from '@linaria/react';`);
+  for (let i = 0; i <= size; i++) {
+    file.write(`
+        export const StyledDiv${i} = styled.div\`
+            background: #fff;
+            border: 1px solid #000;
+            padding: 10px;
+            content: 'StyledDiv${i}';
+        \`;
+    `);
+  }
+
+  file.end();
+};
+
+createBigFile(3_000);


### PR DESCRIPTION
This PRs introduces an in-memory cache for transformed files. This allows us to skip the linaria transform step if the file content hasn't changed and can reduce build times when working with large files.
This feature can be disabled by passing `enableInMemoryCache: false` to the config.