### PR TITLE
migrate from @linaria/babel-preset to @wyw-in-js/babel-preset within README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,21 +13,21 @@ Since the Next.js app directory feature doesn't work with the [@linaria/webpack5
 <details open><summary>npm</summary>
 
 ```sh
-    npm install next-with-linaria @linaria/babel-preset @linaria/core @linaria/react
+    npm install next-with-linaria @wyw-in-js/babel-preset @linaria/core @linaria/react
 ```
 
 </details>
 <details><summary>pnpm</summary>
 
 ```sh
-    pnpm install next-with-linaria @linaria/babel-preset @linaria/core @linaria/react
+    pnpm install next-with-linaria @wyw-in-js/babel-preset @linaria/core @linaria/react
 ```
 
 </details>
 <details><summary>yarn</summary>
 
 ```sh
-    yarn add next-with-linaria @linaria/babel-preset @linaria/core @linaria/react
+    yarn add next-with-linaria @wyw-in-js/babel-preset @linaria/core @linaria/react
 ```
 
 </details>


### PR DESCRIPTION
linaria now uses `@wyw-in-js/babel-preset` instead of `@linaria/babel-preset`.

[feat: migration to wyw-in-js](https://github.com/callstack/linaria/pull/1386)

For Next.js users who use this repository as a guide to installing linaria, the README.md should contain the latest installation instructions.
