### PR TITLE
feat: add prefixer option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-with-linaria",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Linaria support for Next.js App Router",
   "main": "lib/with-linaria.js",
   "scripts": {

--- a/src/add-webpack-config.ts
+++ b/src/add-webpack-config.ts
@@ -70,6 +70,11 @@ export type LinariaConfig = NextConfig & {
      * @default false
      */
     fastCheck?: boolean;
+    /**
+     * Eanbles a prefixer for css rules.
+     * @default true
+     */
+    prefixer?: boolean;
   };
 };
 

--- a/src/loaders/turbopack-transform-loader.ts
+++ b/src/loaders/turbopack-transform-loader.ts
@@ -60,7 +60,7 @@ const turbopackTransformLoader: LoaderType = function (
       root: process.cwd(),
       pluginOptions,
     },
-    cache, // Known issue: https://github.com/Anber/wyw-in-js/issues/134
+    cache,
   } as PartialServices;
 
   transform(transformServices, contentStr, asyncResolve).then(

--- a/src/loaders/turbopack-transform-loader.ts
+++ b/src/loaders/turbopack-transform-loader.ts
@@ -19,7 +19,11 @@ const turbopackTransformLoader: LoaderType = function (
 ) {
   this.async();
 
-  const { fastCheck = true, ...pluginOptions } = this.getOptions() || {};
+  const {
+    fastCheck = true,
+    prefixer = true,
+    ...pluginOptions
+  } = this.getOptions() || {};
 
   const contentStr = content.toString();
 
@@ -58,6 +62,7 @@ const turbopackTransformLoader: LoaderType = function (
       filename: this.resourcePath,
       inputSourceMap: convertSourceMap(inputSourceMap, this.resourcePath),
       root: process.cwd(),
+      prefixer,
       pluginOptions,
     },
     cache,

--- a/src/loaders/webpack-output-css-loader.ts
+++ b/src/loaders/webpack-output-css-loader.ts
@@ -1,3 +1,5 @@
+import zlib from 'node:zlib';
+
 import type { RawLoaderDefinitionFunction } from 'webpack';
 
 type LoaderType = RawLoaderDefinitionFunction;
@@ -12,9 +14,10 @@ const cssOutputLoader: LoaderType = function () {
     return;
   }
 
-  const decodedCss = Buffer.from(css, 'base64').toString();
+  const decodedCss = Buffer.from(css, 'base64');
+  const decompressedCss = zlib.gunzipSync(decodedCss);
 
-  callback(null, decodedCss, undefined);
+  callback(null, decompressedCss.toString('utf-8'), undefined);
 };
 
 export default cssOutputLoader;

--- a/src/loaders/webpack-transform-loader.ts
+++ b/src/loaders/webpack-transform-loader.ts
@@ -22,6 +22,11 @@ export type LinariaLoaderOptions = {
    * @default false
    */
   fastCheck?: boolean;
+  /**
+   * Eanbles a prefixer for css rules.
+   * @default true
+   */
+  prefixer?: boolean;
   preprocessor?: Preprocessor;
   sourceMap?: boolean;
 } & Partial<PluginOptions>;
@@ -36,7 +41,11 @@ const webpackTransformLoader: LoaderType = function (content, inputSourceMap) {
   // tell Webpack this loader is async
   this.async();
 
-  const { fastCheck = true, ...pluginOptions } = this.getOptions() || {};
+  const {
+    fastCheck = true,
+    prefixer = true,
+    ...pluginOptions
+  } = this.getOptions() || {};
 
   const contentStr = content.toString();
 
@@ -75,6 +84,7 @@ const webpackTransformLoader: LoaderType = function (content, inputSourceMap) {
       filename: this.resourcePath,
       inputSourceMap: convertSourceMap(inputSourceMap, this.resourcePath),
       root: process.cwd(),
+      prefixer,
       pluginOptions,
     },
     cache,

--- a/src/loaders/webpack-transform-loader.ts
+++ b/src/loaders/webpack-transform-loader.ts
@@ -2,6 +2,8 @@
  * This was inspired by  https://github.com/callstack/linaria/blob/462739a781e31d5a8266957c0a4800292f452441/packages/webpack5-loader/src/index.ts
  */
 
+import zlib from 'node:zlib';
+
 import type { PluginOptions, Preprocessor, Result } from '@wyw-in-js/transform';
 import { transform, TransformCacheCollection } from '@wyw-in-js/transform';
 import { PartialServices } from '@wyw-in-js/transform/types/transform/helpers/withDefaultServices';
@@ -75,7 +77,7 @@ const webpackTransformLoader: LoaderType = function (content, inputSourceMap) {
       root: process.cwd(),
       pluginOptions,
     },
-    cache, // Known issue: https://github.com/Anber/wyw-in-js/issues/134
+    cache,
   } as PartialServices;
 
   transform(transformServices, contentStr, asyncResolve).then(
@@ -90,19 +92,20 @@ const webpackTransformLoader: LoaderType = function (content, inputSourceMap) {
         );
 
         try {
-          const isGlobalStyle = filename.endsWith(LINARIA_GLOBAL_EXTENSION);
+          const compressedCss = zlib.gzipSync(cssText);
+          const encodedCss = Buffer.from(compressedCss).toString('base64');
 
+          const isGlobalStyle = filename.endsWith(LINARIA_GLOBAL_EXTENSION);
           const cssSuffix = isGlobalStyle
             ? `${LINARIA_GLOBAL_EXTENSION}.css`
             : `${LINARIA_MODULE_EXTENSION}.css`;
-
           const cssFilename = `${filename}${cssSuffix}`;
-          const encodedCss = Buffer.from(cssText).toString('base64');
 
-          /// Example: import "./Component.linaria.module.css!=!./Component?./Component.linaria.module.css"
+          /// Example: import "./Component.linaria.module.css!=!./Component?./Component.linaria.module.css?css=..."
           /// The "!=!" syntax tells webpack to use specific loaders for this import
           /// The "?" parameter is needed for Next.js compatibility as it ignores the "!=!" directive
-          /// Format: "./{basename}.linaria.module.css!=!./{basename}?./{basename}.linaria.module.css"
+          /// The "css=" parameter is used to pass the compressed CSS to the output loader
+
           const importStatement = `import "./${cssFilename}!=!./${filename}?./${cssFilename}?css=${encodedCss}"`;
 
           const finalCode = insertImportStatement(result.code, importStatement);

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,11 @@ export type LinariaTransformLoaderOptions = {
    * @default true
    */
   fastCheck?: boolean;
+  /**
+   * Eanbles a prefixer for css rules.
+   * @default true
+   */
+  prefixer?: boolean;
 } & Partial<Omit<PluginOptions, 'sourceMaps'>>;
 
 export type WithLinariaConfig = NextConfig & {

--- a/src/utils/insert-import.ts
+++ b/src/utils/insert-import.ts
@@ -9,7 +9,9 @@ export function insertImportStatement(
   importStatement: string,
 ): string {
   // Check for existing import statements
-  const importRegex = /import\s+[\s\S]*?;/g;
+  const importRegex =
+    /^\s*(?:import\s+[^;]+?\s+from\s+["'][^"']+["'];|import\s*["'][^"']+["'];)/gm;
+
   const importMatches = [...content.matchAll(importRegex)];
 
   // Case 1: Insert after the last import statement


### PR DESCRIPTION
https://github.com/Anber/wyw-in-js/blob/a549a16fcebe6fc8a7c77b2de1b769dd81520375/packages/transform/src/transform/generators/createStylisPreprocessor.ts#L416-L430

In next major release I would recommend you to set this option to `false` by default. Nextjs have postcss with autoprefixer out of the box, so we have double prefixing and sometimes it cause strange issues.